### PR TITLE
Fix install on OSX if Anaconda is installed

### DIFF
--- a/configure
+++ b/configure
@@ -14,7 +14,7 @@ PKG_TEST_HEADER="<libxml/tree.h>"
 PKG_LIBS="-lxml2"
 
 # Use xml2-config if available
-if [ $(command -v xml2-config) ]; then
+if [[ -n $(command -v xml2-config) && ! ("$OSTYPE" == "darwin"* && "$(xml2-config --cflags)" == *"anaconda"*) ]]; then
   PKGCONFIG_CFLAGS=$(xml2-config --cflags)
   PKGCONFIG_LIBS=$(xml2-config --libs)
 elif [ $(command -v pkg-config) ]; then


### PR DESCRIPTION
If installing libxml2 on OSX with Anaconda in the default path, xml2-config
can detect the version of libxml2 installed by Anaconda, resulting in libxml2
being linked against that, which is incompatible with the version of xml2
installed by default with OSX. This can create problems linking other libraries
down the road, resulting in errors like this:
Error in dyn.load(file, DLLpath = DLLpath, ...) :
  unable to load shared object '/usr/local/lib/R/3.4/site-library/xml2/libs/xml2.so':
  dlopen(/usr/local/lib/R/3.4/site-library/xml2/libs/xml2.so, 6): Library not loaded: @rpath/libxml2.2.dylib
  Referenced from: /usr/local/lib/R/3.4/site-library/xml2/libs/xml2.so
  Reason: image not found
A workaround for this is described at http://www.perfectlyrandom.org/2015/12/13/install-xml2-r-package-on-macos/,
which I have modified to detect if running on OSX with Anaconda to avoid using xml2-config
in that case.
This is potentially a simpler alternative to #192.