### PR TITLE
add ... to xml_structure and descendents, closes #244

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Windows: upgrade to libxml2 2.9.8
 
+* `xml_structure`, `html_structure` gain `...` argument which is passed to `cat`; useful e.g. for outputting to a file (@MichaelChirico, [#244](https://github.com/r-lib/xml2/issues/244))
+
 ## Bugfixes
 
 * Generic xml2 error are now forwarded as R errors. Previously these errors

--- a/R/xml_structure.R
+++ b/R/xml_structure.R
@@ -7,6 +7,7 @@
 #'
 #' @param x HTML/XML document (or part there of)
 #' @param indent Number of spaces to ident
+#' @param ... Arguments (excluding \code{sep}) to be passed to \code{\link[base]{cat}}
 #' @export
 #' @examples
 #' xml_structure(read_xml("<a><b><c/><c/></b><d/></a>"))
@@ -17,44 +18,44 @@
 #'
 #' h <- read_html("<body><p id = 'a'></p><p class = 'c d'></p></body>")
 #' html_structure(h)
-xml_structure <- function(x, indent = 2) {
-  tree_structure(x, indent = indent, html = FALSE)
+xml_structure <- function(x, indent = 2L, ...) {
+  tree_structure(x, indent = indent, html = FALSE, ...)
 }
 
 #' @export
 #' @rdname xml_structure
-html_structure <- function(x, indent = 2) {
-  tree_structure(x, indent = indent, html = TRUE)
+html_structure <- function(x, indent = 2L, ...) {
+  tree_structure(x, indent = indent, html = TRUE, ...)
 }
 
-tree_structure <- function(x, indent = 2, html = FALSE) {
+tree_structure <- function(x, indent = 2L, html = FALSE, ...) {
   UseMethod("tree_structure")
 }
 
 #' @export
-tree_structure.xml_missing <- function(x, indent = 2, html = FALSE) {
+tree_structure.xml_missing <- function(x, indent = 2L, html = FALSE, ...) {
   NA_character_
 }
 
 #' @export
-tree_structure.xml_nodeset <- function(x, indent = 2, html = FALSE) {
+tree_structure.xml_nodeset <- function(x, indent = 2L, html = FALSE, ...) {
   for (i in seq_along(x)) {
-    cat("[[", i, "]]\n", sep = "")
-    print_xml_structure(x[[i]], indent = indent, html = html)
-    cat("\n")
+    cat("[[", i, "]]\n", sep = "", ...)
+    print_xml_structure(x[[i]], indent = indent, html = html, ...)
+    cat("\n", ...)
   }
 
   invisible()
 }
 
 #' @export
-tree_structure.xml_node <-  function(x, indent = 2, html = FALSE) {
-  print_xml_structure(x, indent = indent, html = html)
+tree_structure.xml_node <-  function(x, indent = 2L, html = FALSE, ...) {
+  print_xml_structure(x, indent = indent, html = html, ...)
   invisible()
 }
 
-print_xml_structure <- function(x, prefix = 0, indent = 2, html = FALSE) {
-  padding <- paste(rep(" ", prefix), collapse = "")
+print_xml_structure <- function(x, prefix = 0L, indent = 2L, html = FALSE, ...) {
+  padding <- paste(rep.int(" ", prefix), collapse = "")
   type <- xml_type(x)
 
   if (type == "element") {
@@ -68,7 +69,7 @@ print_xml_structure <- function(x, prefix = 0, indent = 2, html = FALSE) {
       }
 
       if ("class" %in% names(attr)) {
-        html_attrs$class <- paste0(".", gsub(" ", ".", attr[["class"]]))
+        html_attrs$class <- paste0(".", gsub(" ", ".", attr[["class"]], fixed = TRUE))
         attr <- attr[setdiff(names(attr), "class")]
       }
 
@@ -77,16 +78,16 @@ print_xml_structure <- function(x, prefix = 0, indent = 2, html = FALSE) {
       attr_str <- ""
     }
 
-    if (length(attr) > 0) {
+    if (length(attr) > 0L) {
       attr_str <- paste0(attr_str, " [", paste0(names(attr), collapse = ", "), "]")
     }
 
     node <- paste0("<", xml_name(x), attr_str, ">")
 
-    cat(padding, node, "\n", sep = "")
+    cat(padding, node, "\n", sep = "", ...)
     lapply(xml_contents(x), print_xml_structure, prefix = prefix + indent,
-      indent = indent, html = html)
+      indent = indent, html = html, ...)
   } else {
-    cat(padding, "{", type, "}\n", sep = "")
+    cat(padding, "{", type, "}\n", sep = "", ...)
   }
 }

--- a/tests/testthat/test-xml_structure.R
+++ b/tests/testthat/test-xml_structure.R
@@ -7,4 +7,17 @@ test_that("xml_structure", {
     <c>
     <c>
   <d>")
+
+  # indent argument
+  expect_output(xml_structure(read_xml("<a><b><c/><c/></b><d/></a>"), indent = 0L),
+"<a>
+<b>
+<c>
+<c>
+<d>")
+
+  # writing to a file
+  tmp = tempfile()
+  xml_structure(read_xml("<a><b><c/><c/></b><d/></a>"), file = tmp, append = TRUE)
+  expect_equal(readLines(tmp), c("<a>", "  <b>", "    <c>", "    <c>", "  <d>"))
 })

--- a/tests/testthat/test-xml_structure.R
+++ b/tests/testthat/test-xml_structure.R
@@ -16,7 +16,7 @@ test_that("xml_structure", {
 <c>
 <d>")
 
-  # writing to a file
+  # writing to a file, #244
   tmp = tempfile()
   xml_structure(read_xml("<a><b><c/><c/></b><d/></a>"), file = tmp, append = TRUE)
   expect_equal(readLines(tmp), c("<a>", "  <b>", "    <c>", "    <c>", "  <d>"))


### PR DESCRIPTION
#244 

This is the simplest implementation but IMO not ideal:

 - A bit awkward about `sep`. Maybe make `sep` an argument as well? Seems the simplest way to catch duplicated `sep` at the outset. Otherwise will have to look at `match.call`? But I wasn't sure whether to only put a test for `sep` at the top (in `xml_structure` and `html_structure`?l `@export`ed functions? Whenever `cat` shows up?)

 - Seems a bit odd that you have to remember to supply `append = TRUE`... seems reasonable to expect a call to `xml_structure` to make only one file. And the current API means if your desired behavior is to overwrite an existing file with the full output of `xml_structure` (not a particularly odd behavior IMO), you're out of luck (or at least need to do some more manual stuff; I don't think a lazyeval trick with `append = file.exists(file)` will help since I think it will only evaluate once, not at each call?)