### PR TITLE
Using system libxml2 on Mojave

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,9 @@
 * Generic xml2 error are now forwarded as R errors. Previously these errors
   were output to stderr, so could not be suppressed (#209).
 
+* Stop rewritting `xml-config` on macOS El Capitan and later to remove
+  dependency on macOS SDK header package.(@mys721tx, #252)
+
 # xml2 1.2.0
 
 ## Breaking changes

--- a/configure
+++ b/configure
@@ -24,13 +24,6 @@ else
   if [ $? -eq 0 ]; then
     PKGCONFIG_CFLAGS=`xml2-config --cflags`
     PKGCONFIG_LIBS=`xml2-config --libs`
-
-    # MacOS versions El Capitan and later ship a xml2-config which appends `xcrun
-    # --show-sdk-path` to the xml2-config. So we remove it if it is present.
-    # (https://stat.ethz.ch/pipermail/r-sig-mac/2016-September/012046.html)
-    if echo $OSTYPE | grep -q '^darwin1[567]'; then
-      PKGCONFIG_CFLAGS=`echo $PKGCONFIG_CFLAGS | perl -pe "s{\Q\`xcrun -show-sdk-path\`\E}{}"`
-      PKGCONFIG_LIBS=`echo $PKGCONFIG_LIBS | perl -pe "s{\Q\`xcrun -show-sdk-path\`\E}{}"`
     fi
   else
     pkg-config --version >/dev/null 2>&1


### PR DESCRIPTION
`configure` prevents xml2 to find the system libxml2 on macOS Mojave. This PR adds the version number for Mojave.