### PR TITLE
Add pkgdown URL to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
     person("R Foundation", role = "ctb",
       comment = "Copy of R-project homepage cached as example")
     )
-URL: https://github.com/r-lib/xml2
+URL: https://xml2.r-lib.org/, https://github.com/r-lib/xml2
 BugReports: https://github.com/r-lib/xml2/issues
 Depends:
     R (>= 3.1.0)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,5 +1,12 @@
 url: http://xml2.r-lib.org
 
+template:
+  params:
+    docsearch:
+      api_key: fbd8d79ed49f21fc9ca7b2cf601a3f5b
+      index_name: xml2
+    ganalytics: UA-115082821-1
+
 reference:
   - title: Read and write documents
     contents:


### PR DESCRIPTION
* Add pkgdown URL to DESCRIPTION
* Add analytics to `_pkgdown.yml`

Having this url in `DESCRIPTION` will allow auto-linking for pkgdown reference pages.