### PR TITLE
robustify parse_options for zero-length / multiple options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,9 @@
 * Generic xml2 error are now forwarded as R errors. Previously these errors
   were output to stderr, so could not be suppressed (#209).
 
+* Internal functions `parse_options()` now has more robust argument handling
+  (@bastistician, #258).
+
 # xml2 1.2.0
 
 ## Breaking changes

--- a/R/utils.R
+++ b/R/utils.R
@@ -51,7 +51,7 @@ parse_options <- function(arg, options) {
     return(as.integer(arg))
   }
 
-  if (is.null(arg) || !nzchar(arg)) {
+  if (length(arg) == 0 || (length(arg) == 1 && !nzchar(arg))) {
     return(0L)
   }
 


### PR DESCRIPTION
This PR improves argument handling by the internal function `parse_options()`.

#### Non-NULL zero-length options

Previously failed:
```r
parse_options(character(0), xml_parse_options())
#> Error in if (is.null(arg) || !nzchar(arg)) { : missing value where TRUE/FALSE needed
```

Now considered as empty input (just like `NULL`), so the function returns 0:
```r
parse_options(character(0), xml_parse_options())
#> [1] 0
```

#### Multiple options including the empty string

Parsing `c("", "RECOVER")` would always return 0:
```r
parse_options(c("", "RECOVER"), xml_parse_options())
#> [1] 0
```

It is now consistent with parsing reversed options `c("RECOVER", "")`, i.e., it fails since `''` is not a valid option:
```r
parse_options(c("", "RECOVER"), xml_parse_options())
#> Error: `options` '' is not a valid option, should be one of [...]
```

The corresponding change also fixes #238.