### PR TITLE
BUG FIX: if-statement in parse_options() assumed length(arg) == 1

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -51,7 +51,7 @@ parse_options <- function(arg, options) {
     return(as.integer(arg))
   }
 
-  if (is.null(arg) || !nzchar(arg)) {
+  if (is.null(arg) || !any(nzchar(arg))) {
     return(0L)
   }
 


### PR DESCRIPTION
Example before fix:
```r
> Sys.setenv("_R_CHECK_LENGTH_1_LOGIC2_"="TRUE")
> xml2::read_html("")
Error in is.null(arg) || !nzchar(arg) : 
  'length(x) = 3 > 1' in coercion to 'logical(1)'
```
