### PR TITLE
add a type check to xpath_search

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * `write_xml()` and `write_html()` now return NULL invisibly, as they did prior to version 1.3.0 (#307)
 
+* `xml_find_all.xml_node()` fails more informatively the `xpath` parameter is the wrong type (@michaelchirico)
+
 # xml2 1.3.2
 
 * `read_html()` and `read_xml()` now error if passed strings of length greater than one (#121)

--- a/src/xml2_xpath.cpp
+++ b/src/xml2_xpath.cpp
@@ -104,6 +104,9 @@ extern "C" SEXP xpath_search(SEXP node_sxp, SEXP doc_sxp, SEXP xpath_sxp, SEXP n
 
   XPtrNode node(node_sxp);
   XPtrDoc doc(doc_sxp);
+  if (TYPEOF(xpath_sxp) != STRSXP) {
+    Rf_error("XPath must be a string, received %s", type2char(TYPEOF(xpath_sxp)));
+  }
   const char* xpath = CHAR(STRING_ELT(xpath_sxp, 0));
 
   double num_results = REAL(num_results_sxp)[0];

--- a/tests/testthat/test-xml_find.R
+++ b/tests/testthat/test-xml_find.R
@@ -150,3 +150,10 @@ test_that("Searches with entities work (#241)", {
 
   expect_equal(xml_text(field1), "foo bar Quantitative Consultancy")
 })
+
+test_that("A helpful error is given from non-string xpath in xml_find_first/all", {
+  node <- read_xml("<a>1</a>")
+
+  expect_error(xml_find_all(node, 1), "XPath must be a string", fixed = TRUE)
+  expect_error(xml_find_first(node, 1), "XPath must be a string", fixed = TRUE)
+})


### PR DESCRIPTION
Ran into this when making an interactive typo:

```
Error in xml_find_all.xml_node(., pg, "//div[contains(text(), 'Results')]") : 
  STRING_ELT() can only be applied to a 'character vector', not a 'list'
```

The `STRING_ELT` part is likely to be puzzling, so we catch this mistake one line earlier instead.