### PR TITLE
Add copy constructor and assignment operator for XPtr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * `xml_find_all.xml_node()` fails more informatively the `xpath` parameter is the wrong type (@michaelchirico)
 
+* `XPtr` gets explicit copy constructor and assignment operator definitions, which were two missing components of the [Rule of three](https://en.wikipedia.org/wiki/Rule_of_three_(C%2B%2B_programming)) (@michaelchirico)
+
 # xml2 1.3.2
 
 * `read_html()` and `read_xml()` now error if passed strings of length greater than one (#121)

--- a/inst/include/xml2_types.h
+++ b/inst/include/xml2_types.h
@@ -28,7 +28,7 @@ template <typename T> class XPtr {
   }
   
   XPtr& operator=(const XPtr<T> &other) {
-    R_PreserveObject(other.data_)
+    R_PreserveObject(other.data_);
     if (data_ != nullptr) {
       R_ReleaseObject(data_);
     }

--- a/inst/include/xml2_types.h
+++ b/inst/include/xml2_types.h
@@ -29,7 +29,7 @@ template <typename T> class XPtr {
   
   XPtr& operator=(const XPtr<T> &other) {
     R_PreserveObject(other.data_);
-    if (data_ != nullptr) {
+    if (data_ != NULL) {
       R_ReleaseObject(data_);
     }
     data_ = other.data_;

--- a/inst/include/xml2_types.h
+++ b/inst/include/xml2_types.h
@@ -21,6 +21,20 @@ template <typename T> class XPtr {
     data_ = R_MakeExternalPtr((void *) p, R_NilValue, R_NilValue);
     R_PreserveObject(data_);
   }
+  
+  XPtr(const XPtr<T> &old) {
+    data_ = old.data_;
+    R_PreserveObject(data_);
+  }
+  
+  XPtr& operator=(const XPtr<T> &other) {
+    R_PreserveObject(other.data_)
+    if (data_ != nullptr) {
+      R_ReleaseObject(data_);
+    }
+    data_ = other.data_;
+    return *this;
+  }
 
   operator SEXP() const { return data_; }
 


### PR DESCRIPTION
We ran into a segfault, apparently due to double-deletion on destruction of an XPtr (unfortunately I couldn't trace down a good repro of this).

Defining the copy constructor and assignment operator explicitly as here (see also: https://stackoverflow.com/a/4172724/3576984) solved the issue.