### PR TITLE
One `xml_text` example wasn't properly escaped

### DIFF
--- a/R/xml_text.R
+++ b/R/xml_text.R
@@ -17,8 +17,7 @@
 #' x <- read_xml("<p>   Some text    </p>")
 #' xml_text(x, trim = TRUE)
 #'
-#' # xml_double() and xml_integer() are useful for extracting numeric
-#' attributes
+#' # xml_double() and xml_integer() are useful for extracting numeric attributes
 #' x <- read_xml("<plot><point x='1' y='2' /><point x='2' y='1' /></plot>")
 #' xml_integer(xml_find_all(x, "//@x"))
 #' @export

--- a/man/xml_text.Rd
+++ b/man/xml_text.Rd
@@ -44,8 +44,7 @@ xml_text(xml_find_all(x, "//x"))
 x <- read_xml("<p>   Some text    </p>")
 xml_text(x, trim = TRUE)
 
-# xml_double() and xml_integer() are useful for extracting numeric
-attributes
+# xml_double() and xml_integer() are useful for extracting numeric attributes
 x <- read_xml("<plot><point x='1' y='2' /><point x='2' y='1' /></plot>")
 xml_integer(xml_find_all(x, "//@x"))
 }


### PR DESCRIPTION
One `xml_text` example includes the following comment:

```
#' # xml_double() and xml_integer() are useful for extracting numeric attributes
```

However, this text was previously spread across two lines:

```
#' # xml_double() and xml_integer() are useful for extracting numeric 
#' attributes
```

with the second line missing the # in front of it. When these examples are run (i.e. [in the reference docs](https://xml2.r-lib.org/reference/xml_text.html)), this extra text is treated as R code and run. Because `attributes` is an R function, the output is not what's intended:

```
# xml_double() and xml_integer() are useful for extracting numeric
attributes
#> function (x)  .Primitive("attributes")
```

This PR fixes this minor issue by simply moving the hanging word to the line above, which gives it a line length of exactly 80. An alternative solution if lines should be strictly less than 80 would be simply adding a new # in front of this line instead.

