### PR TITLE
Add <iterator> include

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1,3 +1,4 @@
+#include <iterator>
 #include <Rinternals.h>
 #include <vector>
 #include "xml2_utils.h"


### PR DESCRIPTION
std::back_inserter is used on L38:

https://en.cppreference.com/w/cpp/iterator/back_insert_iterator