### PR TITLE
Include Rinternals after vector

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1,6 +1,6 @@
 #include <iterator>
-#include <Rinternals.h>
 #include <vector>
+#include <Rinternals.h>
 #include "xml2_utils.h"
 
 // Wrapper around R's read_bin function

--- a/src/xml2_schema.cpp
+++ b/src/xml2_schema.cpp
@@ -1,9 +1,9 @@
-#include <Rinternals.h>
-
 #include <libxml/xmlschemas.h>
-#include "xml2_types.h"
 #include <vector>
 #include <string>
+
+#include <Rinternals.h>
+#include "xml2_types.h"
 #include "xml2_utils.h"
 
 void handleSchemaError(void* userData, xmlError* error) {


### PR DESCRIPTION
Helps ensure R macros are resolved in the case of conflict (e.g. `<vector>` may start defining a `length()` macro that conflicts with R's)