### PR TITLE
Replace `structure()` by `class()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # xml2 (development version)
 
+* Small speedup for `xml_find_all()` (@mgirlich, #393).
+
 # xml2 1.3.4
 
 * Fixes for R CMD check problems.

--- a/R/classes.R
+++ b/R/classes.R
@@ -7,7 +7,9 @@ xml_node <- function(node = NULL, doc = NULL) {
   if (inherits(node, "xml_node")) {
     node
   } else {
-    structure(list(node = node, doc = doc), class = "xml_node")
+    out <- list(node = node, doc = doc)
+    class(out) <- "xml_node"
+    out
   }
 }
 
@@ -38,7 +40,9 @@ xml_document <- function(doc) {
     class(x) <- c("xml_document", class(x))
     x
   } else {
-    structure(list(doc = doc), class = "xml_document")
+    out <- list(doc = doc)
+    class(out) <- "xml_document"
+    out
   }
 }
 
@@ -75,7 +79,8 @@ xml_nodeset <- function(nodes = list(), deduplicate = TRUE) {
   if (isTRUE(deduplicate)) {
     nodes <- nodes[!.Call(nodes_duplicated, nodes)]
   }
-  structure(nodes, class = "xml_nodeset")
+  class(nodes) <- "xml_nodeset"
+  nodes
 }
 
 #' @param nodes A list (possible nested) of external pointers to nodes
@@ -200,7 +205,9 @@ format_attributes <- function(x) {
 #' @export
 #' @keywords internal
 xml_missing <- function() {
-  structure(list(), class = "xml_missing")
+  out <- list()
+  class(out) <- "xml_missing"
+  out
 }
 
 #' @export
@@ -243,7 +250,8 @@ as.character.xml_missing <- function(x, ...) {
 #' as.character(x)
 #' @export
 xml_cdata <- function(content) {
-  structure(content, class = "xml_cdata")
+  class(content) <- "xml_cdata"
+  content
 }
 
 #' Construct a comment node
@@ -255,7 +263,8 @@ xml_cdata <- function(content) {
 #' as.character(x)
 #' @export
 xml_comment <- function(content) {
-  structure(content, class = "xml_comment")
+  class(content) <- "xml_comment"
+  content
 }
 
 #' Construct a document type definition
@@ -281,5 +290,7 @@ xml_comment <- function(content) {
 #' <doc>This is a valid document &foo; !</doc>')
 #' @export
 xml_dtd <- function(name = "", external_id = "", system_id = "") {
-  structure(list(name = name, external_id = external_id, system_id = system_id), class = "xml_dtd")
+  out <- list(name = name, external_id = external_id, system_id = system_id)
+  class(out) <- "xml_dtd"
+  out
 }

--- a/R/xml_modify.R
+++ b/R/xml_modify.R
@@ -123,10 +123,11 @@ create_node <- function(.value, ..., .parent, .copy) {
   parts <- strsplit(.value, ":")[[1]]
   if (length(parts) == 2 && !is.null(.parent$node)) {
       namespace <- .Call(ns_lookup, .parent$doc, .parent$node, parts[[1]])
-      node <- structure(list(node = .Call(node_new_ns, parts[[2]], namespace), doc = .parent$doc), class = "xml_node")
+      node <- list(node = .Call(node_new_ns, parts[[2]], namespace), doc = .parent$doc)
   } else {
-    node <- structure(list(node = .Call(node_new, .value), doc = .parent$doc), class = "xml_node")
+    node <- list(node = .Call(node_new, .value), doc = .parent$doc)
   }
+  class(node) <- "xml_node"
 
   args <- list(...)
   named <- has_names(args)
@@ -296,7 +297,9 @@ xml_set_namespace <- function(.x, prefix = "", uri = "") {
 # TODO: jimhester 2016-12-16 Deprecate this in the future?
 xml_new_document <- function(version = "1.0", encoding = "UTF-8") {
   doc <- .Call(doc_new, version, encoding)
-  structure(list(doc = doc), class = "xml_document")
+  out <- list(doc = doc)
+  class(out) <- "xml_document"
+  out
 }
 
 #' @param .version The version number of the document, passed to `xml_new_document(version)`.


### PR DESCRIPTION
This gives a small performance improvement, e.g. for `xml_find_all(flatten = TRUE)`

``` r
library(xml2)

path <- xml2_example("cd_catalog.xml")
xml <- read_xml(path)
cds <- xml_find_all(xml, "CD")

find <- function() {
  xml_find_all(cds, "TITLE", flatten = FALSE)
}

bench::mark(
  find()
)

# Before
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 find()        400µs    428µs     2165.    30.3KB     10.3

# After
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 find()        324µs    360µs     2529.    30.3KB     8.20
```
<sup>Created on 2023-06-01 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

This helps towards #394.