### PR TITLE
Fix xml_add_parent segfault

### DIFF
--- a/R/xml_modify.R
+++ b/R/xml_modify.R
@@ -210,7 +210,7 @@ xml_add_parent <- function(.x, .value, ...) {
 
 #' @export
 xml_add_parent.xml_node <- function(.x, .value, ...) {
-  new_parent <- xml_replace(.x, .value = .value, ..., .copy = FALSE)
+  new_parent <- xml_replace(.x, .value = .value, ..., .copy = TRUE)
   node <- xml_add_child(new_parent, .value = .x, .copy = FALSE)
 
   invisible(node)

--- a/tests/testthat/test-modify-xml.R
+++ b/tests/testthat/test-modify-xml.R
@@ -197,7 +197,7 @@ test_that("xml_add_parent works with xml_missing input", {
 test_that("xml_add_parent not generating segfault during iteration", {
   add_parent <- function() {
     fruits <- read_xml("<fruits>
-      <apple color='red'></apple>
+      <apple></apple>
       </fruits>")
     xml_add_parent(fruits, read_xml("<food></food>"))
   }

--- a/tests/testthat/test-modify-xml.R
+++ b/tests/testthat/test-modify-xml.R
@@ -194,6 +194,17 @@ test_that("xml_add_parent works with xml_missing input", {
     expect_equal(xml_name(xml_children(y)), c("em", "em"))
 })
 
+test_that("xml_add_parent not generating segfault during iteration", {
+  add_parent <- function() {
+    fruits <- read_xml("<fruits>
+      <apple color='red'></apple>
+      </fruits>")
+    xml_add_parent(fruits, read_xml("<food></food>"))
+  }
+
+  expect_no_error(for(i in 1:100) add_parent())
+})
+
 test_that("xml_new_document adds a default character encoding", {
 
   x <- read_xml("<root>\u00E1\u00FC\u00EE</root>")


### PR DESCRIPTION
closes #339

Adding `.copy = TRUE` in xml_replace() makes the function stable for iterations. 