### PR TITLE
Remove unused header

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -2,7 +2,6 @@
 #include <Rinternals.h>
 #undef R_NO_REMAP
 
-#include <R.h>
 #include <stdlib.h> // for NULL
 #include <R_ext/Rdynload.h>
 


### PR DESCRIPTION
Our tooling flagged this inclusion as unused, and looking around I think everything needed is pulled from <Rinternals.h> (`SEXP`) and <R_ext/Rdynload.h> (`R_CallMethodDef`, `DL_FUNC`, `R_registerRoutines`, `R_useDynamicSymbols`) so that seems correct.