### PR TITLE
double-truncate to avoid inefficient encodeString() usage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # xml2 (development version)
 
 * Remove unused dependencies on glue, withr and lifecycle (@mgirlich).
+* `print()` is faster for very long `xml_nodeset` inputs (#366, @michaelchirico).
 
 # xml2 1.3.5
 

--- a/tests/testthat/_snaps/xml_nodeset.md
+++ b/tests/testthat/_snaps/xml_nodeset.md
@@ -15,3 +15,22 @@
        [9] <div id="more_if_no_javascript"><a href="/search/">More</a></div>
       [10] <div class="magnifyingglass navbarSprite"></div>
 
+---
+
+    Code
+      print(x, width = 13L)
+    Output
+      {xml_document}
+      <doc>
+      [1] <a>123 ...
+      [2] <b>123 ...
+      [3] <c>12\ ...
+    Code
+      print(x, width = 14L)
+    Output
+      {xml_document}
+      <doc>
+      [1] <a>1234 ...
+      [2] <b>1234 ...
+      [3] <c>12\\ ...
+

--- a/tests/testthat/test-xml_nodeset.R
+++ b/tests/testthat/test-xml_nodeset.R
@@ -72,8 +72,24 @@ test_that("methods work on empty nodesets", {
 })
 
 test_that("print method is correct", {
+  skip_if(getOption("width") < 20L, "Screen too narrow")
+
   x <- read_html(test_path("lego.html.bz2"))
   body <- xml_find_first(x, "//body")
   divs <- xml_find_all(body, ".//div")[1:10]
   expect_snapshot(print(divs))
+
+  # double-substring() logic
+  s <- c(
+    "123456789\\", # always too wide, '\' never encoded
+    "12345",       # always fits
+    "12\\45"       # doesn't fit when '\' is encoded
+  )
+  # embed as text on nodes <a>,<b>,<c>
+  s <- sprintf("<%1$s>%2$s</%1$s>", letters[1:3], s)
+  x <- read_xml(sprintf("<doc>%s</doc>", paste(s, collapse="")))
+  expect_snapshot({
+    print(x, width = 13L)
+    print(x, width = 14L)
+  })
 })


### PR DESCRIPTION
Closes #366.

There are some existing tests that were broken in as I was working on this, so I think those plus the new test are enough.

---

Re: the example raised in the issue, I see timing drop from ~1s to ~0.25s on my machine. Still noticeably slow, but a definite improvement. A quick profile shows we're going to need to drop to C++ to do any better.