### PR TITLE
Fix cross compilation issue

### DIFF
--- a/R/xml_parse.R
+++ b/R/xml_parse.R
@@ -41,7 +41,7 @@
 #' @param verbose When reading from a slow connection, this prints some
 #'    output on every iteration so you know its working.
 #' @param options Set parsing options for the libxml2 parser. Zero or more of
-#' \Sexpr[results=rd]{xml2:::describe_options(xml2:::xml_parse_options())}
+#' \Sexpr[results=rd, stage=build]{xml2:::describe_options(xml2:::xml_parse_options())}
 #' @return An XML document. HTML is normalised to valid XML - this may not
 #'   be exactly the same transformation performed by the browser, but it's
 #'   a reasonable approximation.

--- a/man/read_xml.Rd
+++ b/man/read_xml.Rd
@@ -55,7 +55,7 @@ encoding directive, this allows you to supply a default.}
 \item{as_html}{Optionally parse an xml file as if it's html.}
 
 \item{options}{Set parsing options for the libxml2 parser. Zero or more of
-\Sexpr[results=rd]{xml2:::describe_options(xml2:::xml_parse_options())}}
+\Sexpr[results=rd, stage=build]{xml2:::describe_options(xml2:::xml_parse_options())}}
 
 \item{base_url}{When loading from a connection, raw vector or literal
 html/xml, this allows you to specify a base url for the document. Base


### PR DESCRIPTION
This package cannot be cross compiled, because it tries to evaluate something at install time. Therefore p3m and webr and r-universe need to patch this package, which is a headache, e.g https://github.com/r-wasm/xml2/tree/webr

This PR changes it such that this code is evaluated during CMD build, instead of CMD INSTALL, such that we can cross compile from a source package without having to run anything.

@georgestagg @tylfin

