### PR TITLE
Mark R_init_xml2 as visible

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -4,6 +4,7 @@
 
 #include <stdlib.h> // for NULL
 #include <R_ext/Rdynload.h>
+#include <R_ext/Visibility.h>
 
 /* FIXME:
    Check these declarations against the C/Fortran source code.
@@ -141,7 +142,7 @@ static const R_CallMethodDef CallEntries[] = {
     {NULL, NULL, 0}
 };
 
-void R_init_xml2(DllInfo *dll)
+attribute_visible void R_init_xml2(DllInfo *dll)
 {
     R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
     R_useDynamicSymbols(dll, FALSE);


### PR DESCRIPTION
See https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Controlling-visibility.

As it is, {xml2} fails to compile under `-fvisibility=hidden`.

This is related to #450