### PR TITLE
Cite Alpine explicitly in configure log

### DIFF
--- a/configure
+++ b/configure
@@ -62,7 +62,7 @@ echo "#include $PKG_TEST_HEADER" | ${CC} ${CPPFLAGS} ${PKG_CFLAGS} ${CFLAGS} -E 
 if [ $? -ne 0 ]; then
   echo "------------------------- ANTICONF ERROR ---------------------------"
   echo "Configuration failed because $PKG_CONFIG_NAME was not found. Try installing:"
-  echo " * deb: $PKG_DEB_NAME (Debian, Ubuntu, etc)"
+  echo " * deb: $PKG_DEB_NAME (Debian, Ubuntu, Alpine, etc)"
   echo " * rpm: $PKG_RPM_NAME (Fedora, CentOS, RHEL)"
   echo " * csw: $PKG_CSW_NAME (Solaris)"
   echo "If $PKG_CONFIG_NAME is already installed, check that 'pkg-config' is in your"


### PR DESCRIPTION
Useful to just read off in minimal environments like `docker.io/rhub/r-minimal:devel`; I trust `Alpine` is common enough to warrant surfacing here instead of just leaving in `etc`.