### PR TITLE
Add "Supported By Posit" badge to xml2 website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,57 +6,58 @@ template:
 
   includes:
     in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
       <script defer data-domain="xml2.r-lib.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
 
 development:
   mode: auto
 
 reference:
-  - title: Read and write documents
-    contents:
-    - starts_with("read_")
-    - starts_with("write_")
-    - starts_with("download_")
+- title: Read and write documents
+  contents:
+  - starts_with("read_")
+  - starts_with("write_")
+  - starts_with("download_")
 
-  - title: Class coercion
-    contents:
-    - starts_with("as_")
+- title: Class coercion
+  contents:
+  - starts_with("as_")
 
-  - title: URL manipulation
-    contents:
-    - starts_with("url_")
+- title: URL manipulation
+  contents:
+  - starts_with("url_")
 
-  - title: Create and modify and document
-    contents:
-    - starts_with("xml_new")
-    - starts_with("xml_add")
-    - starts_with("xml_set")
-    - xml_cdata
-    - xml_comment
-    - xml_dtd
-    - xml_ns_strip
-    - xml_replace
-    - xml_remove
+- title: Create and modify and document
+  contents:
+  - starts_with("xml_new")
+  - starts_with("xml_add")
+  - starts_with("xml_set")
+  - xml_cdata
+  - xml_comment
+  - xml_dtd
+  - xml_ns_strip
+  - xml_replace
+  - xml_remove
 
-  - title: Search and navigate a document
-    contents:
-    - starts_with("xml_find")
-    - starts_with("xml_attr")
-    - xml_path
+- title: Search and navigate a document
+  contents:
+  - starts_with("xml_find")
+  - starts_with("xml_attr")
+  - xml_path
 
-  - title: Inspect a document
-    contents:
-    - starts_with("xml_ns")
-    - xml_children
-    - ends_with("structure")
-    - xml_type
-    - xml_url
-    - xml_validate
+- title: Inspect a document
+  contents:
+  - starts_with("xml_ns")
+  - xml_children
+  - ends_with("structure")
+  - xml_type
+  - xml_url
+  - xml_validate
 
-  - title: Utilities
-    contents:
-    - ends_with("serialize")
-    - xml2_example
+- title: Utilities
+  contents:
+  - ends_with("serialize")
+  - xml2_example
 
 news:
   releases:


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the xml2 website.

## Background

We've recently started adding a "Supported by Posit" badge across all Posit package websites to create a more cohesive brand presence. The badge appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. @hadley is involved with this initiative.

The following websites already have the "Supported by Posit" badge: [ggplot2](https://ggplot2.tidyverse.org), [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html), [gt](https://gt.rstudio.com), [Plotnine](https://plotnine.org), [Pointblank](https://posit-dev.github.io/pointblank/), [pointblank](https://rstudio.github.io/pointblank/), and [Quarto](https://quarto.org).

See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file
- Standardized indentation in `_pkgdown.yml`

## Screenshots

At 1200px browser width:

![Screenshot of xml2 website at 1200px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/xml2-1200.png)

At 992px browser width:

![Screenshot of xml2 website at 992px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/xml2-992.png)

At 991px browser width:

![Screenshot of xml2 website at 991px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/xml2-991.png)

