### PR TITLE
Include what you use pass on headers

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1,4 +1,6 @@
 #include <Rinternals.h>
+#include <algorithm> // std::copy
+#include <cstddef> // size_t
 #include <iterator>
 #include <vector>
 #include "xml2_utils.h"

--- a/src/connection.h
+++ b/src/connection.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <Rinternals.h>
-#include <algorithm>
 #include <cstring>
 
 SEXP read_bin(SEXP con, size_t bytes = 64 * 1024);

--- a/src/init.c
+++ b/src/init.c
@@ -1,5 +1,6 @@
 #include <Rinternals.h>
 #include <stdlib.h> // for NULL
+#include <R_ext/Boolean.h> // FALSE
 #include <R_ext/Rdynload.h>
 #include <R_ext/Visibility.h>
 

--- a/src/xml2_doc.cpp
+++ b/src/xml2_doc.cpp
@@ -1,11 +1,14 @@
+#include <R_ext/Error.h> // Rf_error
 #include <Rinternals.h>
 #include <libxml/encoding.h> // xmlCharEncoding, xmlGetCharEncodingName, xmlParseCharEncoding
 #include <libxml/parser.h>
 #include <libxml/xmlstring.h> // xmlChar, xmlStrdup
+#include <libxml/xmlversion.h> // LIBXML_VERSION
 #include <libxml/HTMLparser.h>
 #include "xml2_types.h"
 #include "xml2_utils.h"
 #include <cstring>
+#include <string> // std::string
 
 // [[export]]
 extern "C" SEXP  xml_parse_options_() {

--- a/src/xml2_init.c
+++ b/src/xml2_init.c
@@ -1,7 +1,10 @@
+#include <R_ext/Error.h> // Rf_error, Rf_warning
 #include <Rinternals.h>
 #include <libxml/xmlversion.h>
 #include <libxml/xmlerror.h>
 #include <libxml/parser.h>
+#include <stdarg.h> // va_start
+#include <stdio.h> // BUFSIZ, vsnprintf
 #include <string.h>
 
 /* * *

--- a/src/xml2_namespace.cpp
+++ b/src/xml2_namespace.cpp
@@ -1,5 +1,8 @@
+#include <R_ext/Error.h> // Rf_error
 #include <Rinternals.h>
 #include <libxml/tree.h>
+#include <libxml/xmlversion.h> // LIBXML_DOTTED_VERSION
+#include <cstddef> // NULL
 
 #include "xml2_types.h"
 #include "xml2_utils.h"

--- a/src/xml2_node.cpp
+++ b/src/xml2_node.cpp
@@ -1,10 +1,13 @@
+#include <R_ext/Error.h> // Rf_error
+#include <R_ext/Arith.h> // NA_INTEGER
 #include <Rinternals.h>
 #include <libxml/tree.h>
-#include <fstream>
-#include <sstream>
-#include <vector>
-#include <string>
+#include <libxml/xmlstring.h> // xmlChar, xmlStrEqual
+#include <algorithm> // std::equal
+#include <cstddef> // NULL, size_t
 #include <set>
+#include <string>
+#include <vector>
 
 #include "xml2_types.h"
 #include "xml2_utils.h"

--- a/src/xml2_output.cpp
+++ b/src/xml2_output.cpp
@@ -1,7 +1,12 @@
+#include <R_ext/Error.h> // Rf_error
 #include <Rinternals.h>
 #include <libxml/tree.h>
 #include <libxml/HTMLtree.h>
+#include <libxml/xmlIO.h> // xmlOutputWriteCallback
+#include <libxml/xmlmemory.h> // xmlFree
 #include <libxml/xmlsave.h>
+#include <libxml/xmlversion.h> // LIBXML_VERSION
+#include <cstddef> // NULL, size_t
 
 #include "connection.h"
 #include "xml2_types.h"

--- a/src/xml2_schema.cpp
+++ b/src/xml2_schema.cpp
@@ -1,5 +1,8 @@
 #include <Rinternals.h>
+#include <libxml/xmlerror.h> // xmlError
 #include <libxml/xmlschemas.h>
+#include <libxml/xmlversion.h> // LIBXML_VERSION
+#include <cstddef> // size_t
 #include <vector>
 #include <string>
 

--- a/src/xml2_url.cpp
+++ b/src/xml2_url.cpp
@@ -1,5 +1,11 @@
+#include <R_ext/Arith.h> // NA_INTEGER
+#include <R_ext/Error.h> // Rf_error
 #include <Rinternals.h>
 #include <libxml/uri.h>
+#include <libxml/xmlmemory.h> // xmlFree
+#include <libxml/xmlstring.h> // xmlChar
+#include <libxml/xmlversion.h> // LIBXML_VERSION
+#include <cstddef> // NULL
 #include "xml2_utils.h"
 
 // [[export]]

--- a/src/xml2_utils.h
+++ b/src/xml2_utils.h
@@ -1,8 +1,12 @@
 #ifndef __XML2_XML_UTILS__
 #define __XML2_XML_UTILS__
 
+#include <R_ext/Error.h> // Rf_error
 #include <Rinternals.h>
 #include <libxml/tree.h>
+#include <libxml/xmlmemory.h> // xmlFree
+#include <libxml/xmlstring.h> // xmlChar
+#include <cstddef> // NULL, size_t
 #include <map>
 #include <string>
 

--- a/src/xml2_xpath.cpp
+++ b/src/xml2_xpath.cpp
@@ -1,9 +1,14 @@
+#include <R_ext/Arith.h> // R_PosInf
+#include <R_ext/Error.h> // Rf_error
 #include <Rinternals.h>
+#include <libxml/xmlstring.h> // xmlChar
 #include <libxml/xpath.h>
 #include <libxml/xpathInternals.h>
 #include <libxml/tree.h>
 #include "xml2_types.h"
 #include <algorithm>
+#include <climits> // INT_MAX
+#include <cstddef> // NULL
 
 class XmlSeeker {
   xmlXPathContext* context_;


### PR DESCRIPTION
Following up the tidyteam meeting today with a first suggested PR as an earmark/test balloon lest I forget. A few notes:

 1. We could also consider fully "modularizing" by splitting up the sources into .h, .cpp pairs, where the .h file declares the routines and gives some documentary comments, and the .cpp file gives the implementations. Often, this further cleans up the inclusions by making clear what's needed for the API aspect of the routines (input/return types, etc.) vs. what's required for the implementation. Omitted this for now as it's a bit more involved / not sure preferences.
 2. `<cstddef>` for `NULL` gave me a bit of pause because `src/init.c` uses `<stdlib.h>` for that. I think this is partly just a C vs. C++ thing, e.g. https://stackoverflow.com/q/12023476/3576984; we might consider `<stddef.h>` for a narrower inclusion in init.c.
 3. If you'd like me to play around with getting this enforced in GHA, let me know. IINM it's https://clang.llvm.org/extra/clang-tidy/checks/misc/include-cleaner.html.
 4. I added the annotations of which header gives which symbol (1) for easier review and (2) to match a few other files like src/xml2_doc.cpp. The risk is that these annotations fall out of sync with the actual code over time.
 5. Some style guides recommendation around the order to use for inclusions ([e.g.](https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes)). I'm indifferent here and didn't make any changes, besides that my new inclusions here are roughly alphabetized.