### PR TITLE
Vectorize xml_find_* helpers

### DIFF
--- a/R/xml_find.R
+++ b/R/xml_find.R
@@ -178,7 +178,7 @@ xml_find_num.xml_nodeset <- function(x, xpath, ns = xml_ns(x)) {
     return(numeric())
   }
 
-  vapply(x, function(x) xml_find_num(x, xpath = xpath, ns = ns), numeric(1))
+  .Call(xpath_search_atomic, x, xpath, ns, 3L)
 }
 
 #' @export
@@ -205,7 +205,7 @@ xml_find_int.xml_nodeset <- function(x, xpath, ns = xml_ns(x)) {
     return(integer())
   }
 
-  vapply(x, function(x) xml_find_int(x, xpath = xpath, ns = ns), integer(1))
+  .Call(xpath_search_atomic, x, xpath, ns, 4L)
 }
 
 #' @export
@@ -232,7 +232,7 @@ xml_find_chr.xml_nodeset <- function(x, xpath, ns = xml_ns(x)) {
     return(character())
   }
 
-  vapply(x, function(x) xml_find_chr(x, xpath = xpath, ns = ns), character(1))
+  .Call(xpath_search_atomic, x, xpath, ns, 1L)
 }
 
 #' @export
@@ -259,7 +259,7 @@ xml_find_lgl.xml_nodeset <- function(x, xpath, ns = xml_ns(x)) {
     return(logical())
   }
 
-  vapply(x, function(x) xml_find_lgl(x, xpath = xpath, ns = ns), logical(1))
+  .Call(xpath_search_atomic, x, xpath, ns, 2L)
 }
 
 #' @export

--- a/src/init.c
+++ b/src/init.c
@@ -70,6 +70,7 @@ extern SEXP url_unescape_(SEXP);
 extern SEXP xml_parse_options_(void);
 extern SEXP xml_save_options_(void);
 extern SEXP xpath_search(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP xpath_search_atomic(SEXP, SEXP, SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
     {"doc_has_root",              (DL_FUNC) &doc_has_root,              1},
@@ -134,6 +135,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"xml_parse_options_",        (DL_FUNC) &xml_parse_options_,        0},
     {"xml_save_options_",         (DL_FUNC) &xml_save_options_,         0},
     {"xpath_search",              (DL_FUNC) &xpath_search,              5},
+    {"xpath_search_atomic",       (DL_FUNC) &xpath_search_atomic,       4},
     {NULL, NULL, 0}
 };
 

--- a/src/xml2_xpath.cpp
+++ b/src/xml2_xpath.cpp
@@ -4,6 +4,7 @@
 #include <libxml/tree.h>
 #include "xml2_types.h"
 #include <algorithm>
+#include <cmath>
 
 class XmlSeeker {
   xmlXPathContext* context_;
@@ -18,10 +19,10 @@ public:
     context_->node = node;
   }
 
-  void registerNamespace(SEXP nsMap) {
+  static bool registerNamespace(xmlXPathContext* context, SEXP nsMap) {
     R_xlen_t n = Rf_xlength(nsMap);
     if (n == 0) {
-      return;
+      return true;
     }
 
     SEXP prefix = Rf_getAttrib(nsMap, R_NamesSymbol);
@@ -30,8 +31,15 @@ public:
       xmlChar* prefixI = (xmlChar*) CHAR(STRING_ELT(prefix, i));
       xmlChar* urlI = (xmlChar*) CHAR(STRING_ELT(nsMap, i));
 
-      if (xmlXPathRegisterNs(context_, prefixI, urlI) != 0)
-        Rf_error("Failed to register namespace (%s <-> %s)", prefixI, urlI);
+      if (xmlXPathRegisterNs(context, prefixI, urlI) != 0)
+        return false;
+    }
+    return true;
+  }
+
+  void registerNamespace(SEXP nsMap) {
+    if (!registerNamespace(context_, nsMap)) {
+      Rf_error("Failed to register namespace");
     }
   }
 
@@ -117,4 +125,158 @@ extern "C" SEXP xpath_search(SEXP node_sxp, SEXP doc_sxp, SEXP xpath_sxp, SEXP n
   XmlSeeker seeker(doc, node.checked_get());
   seeker.registerNamespace(nsMap_sxp);
   return seeker.search(xpath, num_results);
+}
+
+// [[export]]
+extern "C" SEXP xpath_search_atomic(SEXP nodeset_sxp, SEXP xpath_sxp, SEXP nsMap_sxp, SEXP type_sxp) {
+  if (TYPEOF(xpath_sxp) != STRSXP || Rf_xlength(xpath_sxp) == 0) {
+    Rf_error("XPath must be a string");
+  }
+  const char* xpath = CHAR(STRING_ELT(xpath_sxp, 0));
+  int target_type = INTEGER(type_sxp)[0];
+
+  xmlXPathCompExprPtr comp = xmlXPathCompile((const xmlChar*)xpath);
+  if (comp == NULL) {
+    Rf_error("Invalid XPath: %s", xpath);
+  }
+
+  int n = Rf_xlength(nodeset_sxp);
+  SEXP out = R_NilValue;
+  switch (target_type) {
+    case 1: out = PROTECT(Rf_allocVector(STRSXP, n)); break;
+    case 2: out = PROTECT(Rf_allocVector(LGLSXP, n)); break;
+    case 3: out = PROTECT(Rf_allocVector(REALSXP, n)); break;
+    case 4: out = PROTECT(Rf_allocVector(INTSXP, n)); break;
+    default:
+      xmlXPathFreeCompExpr(comp);
+      Rf_error("Unknown target type %d", target_type);
+  }
+
+  xmlDocPtr current_doc = NULL;
+  xmlXPathContextPtr context = NULL;
+
+  for (int i = 0; i < n; ++i) {
+    SEXP x_i = VECTOR_ELT(nodeset_sxp, i);
+    if (TYPEOF(x_i) != VECSXP || Rf_xlength(x_i) < 2) {
+      if (context != NULL) xmlXPathFreeContext(context);
+      xmlXPathFreeCompExpr(comp);
+      UNPROTECT(1);
+      Rf_error("nodeset element %d is not a valid xml_node", i + 1);
+    }
+    SEXP node_sxp = VECTOR_ELT(x_i, 0);
+    SEXP doc_sxp = VECTOR_ELT(x_i, 1);
+
+    if (TYPEOF(node_sxp) != EXTPTRSXP || TYPEOF(doc_sxp) != EXTPTRSXP) {
+      if (context != NULL) xmlXPathFreeContext(context);
+      xmlXPathFreeCompExpr(comp);
+      UNPROTECT(1);
+      Rf_error("nodeset element %d has invalid external pointer", i + 1);
+    }
+
+    xmlNodePtr node = (xmlNodePtr) R_ExternalPtrAddr(node_sxp);
+    xmlDocPtr doc = (xmlDocPtr) R_ExternalPtrAddr(doc_sxp);
+    if (node == NULL || doc == NULL) {
+      if (context != NULL) xmlXPathFreeContext(context);
+      xmlXPathFreeCompExpr(comp);
+      UNPROTECT(1);
+      Rf_error("external pointer is not valid");
+    }
+
+    if (doc != current_doc || context == NULL) {
+      if (context != NULL) {
+        xmlXPathFreeContext(context);
+      }
+      current_doc = doc;
+      context = xmlXPathNewContext(current_doc);
+      if (context == NULL) {
+        xmlXPathFreeCompExpr(comp);
+        UNPROTECT(1);
+        Rf_error("Failed to create XPath context");
+      }
+      if (!XmlSeeker::registerNamespace(context, nsMap_sxp)) {
+        xmlXPathFreeContext(context);
+        xmlXPathFreeCompExpr(comp);
+        UNPROTECT(1);
+        Rf_error("Failed to register namespace");
+      }
+    }
+    context->node = node;
+
+    xmlXPathObjectPtr res = xmlXPathCompiledEval(comp, context);
+    if (res == NULL) {
+      if (context != NULL) xmlXPathFreeContext(context);
+      xmlXPathFreeCompExpr(comp);
+      UNPROTECT(1);
+      Rf_error("Evaluation of XPath `%s` failed on node %d", xpath, i + 1);
+    }
+
+    switch (target_type) {
+      case 1: // CHR
+        if (res->type == XPATH_STRING) {
+          SET_STRING_ELT(out, i, Rf_mkCharCE((char*)res->stringval, CE_UTF8));
+        } else {
+          int type = res->type;
+          xmlXPathFreeObject(res);
+          if (context != NULL) xmlXPathFreeContext(context);
+          xmlXPathFreeCompExpr(comp);
+          UNPROTECT(1);
+          Rf_error("Result of XPath `%s` is not a string (type: %d)", xpath, type);
+        }
+        break;
+      case 2: // LGL
+        if (res->type == XPATH_BOOLEAN) {
+          LOGICAL(out)[i] = res->boolval ? 1 : 0;
+        } else {
+          int type = res->type;
+          xmlXPathFreeObject(res);
+          if (context != NULL) xmlXPathFreeContext(context);
+          xmlXPathFreeCompExpr(comp);
+          UNPROTECT(1);
+          Rf_error("Result of XPath `%s` is not a logical (type: %d)", xpath, type);
+        }
+        break;
+      case 3: // NUM
+        if (res->type == XPATH_NUMBER) {
+          REAL(out)[i] = res->floatval;
+        } else {
+          int type = res->type;
+          xmlXPathFreeObject(res);
+          if (context != NULL) xmlXPathFreeContext(context);
+          xmlXPathFreeCompExpr(comp);
+          UNPROTECT(1);
+          Rf_error("Result of XPath `%s` is not a number (type: %d)", xpath, type);
+        }
+        break;
+      case 4: // INT
+        if (res->type == XPATH_NUMBER) {
+          double val = res->floatval;
+          if (std::isnan(val) || val == std::floor(val)) {
+            INTEGER(out)[i] = (int)val;
+          } else {
+            xmlXPathFreeObject(res);
+            if (context != NULL) xmlXPathFreeContext(context);
+            xmlXPathFreeCompExpr(comp);
+            UNPROTECT(1);
+            Rf_error("Result of XPath `%s` is not an integer", xpath);
+          }
+        } else {
+          int type = res->type;
+          xmlXPathFreeObject(res);
+          if (context != NULL) xmlXPathFreeContext(context);
+          xmlXPathFreeCompExpr(comp);
+          UNPROTECT(1);
+          Rf_error("Result of XPath `%s` is not a whole number (type: %d)", xpath, type);
+        }
+        break;
+    }
+    xmlXPathFreeObject(res);
+  }
+
+  if (context != NULL) {
+    xmlXPathFreeContext(context);
+  }
+  xmlXPathFreeCompExpr(comp);
+  UNPROTECT(1); // out
+
+  return out;
 }


### PR DESCRIPTION
In {lintr}, I found that a natural replacement for the common idiom `xml_text(xml_find_first(x, "XPATH"))` is `xml_find_chr(x, "string(XPATH)")`. This already dramatically reduces the memory footprint, but the R-side looping kills the performance a bit (e.g. 30% slower).

This PR proposes vectorizing the whole operation in C(++) instead, providing 10-40x performance improvement and 50-75% memory reduction.

PR prepared by Gemini. There are a number of similar ways to implement the proposal -- filing first to probe interest in maintaining this approach before attempting to fine-tune the details.

Given the apparent "correctness" of using `xml_find_chr()`, I will be changing {lintr} to use it anyway -- it would be nice to get the free performance enhancement, too.

### Benchmark Results

#### Medium Nodeset ($N = 500$ items)

| Expression | Median Time | Iterations/sec | Memory Allocated | Speedup vs Baseline |
| :--- | :--- | :--- | :--- | :--- |
| `xml_text(xml_find_first(x, 'name'))` | 3.85 ms | 254 | 7.91 KB | 1.0x *(baseline)* |
| `xml_find_chr(x, 'string(name)')` *(OLD `vapply`)* | 4.55 ms | 213 | 3.95 KB | 0.85x |
| `xml_find_chr(x, 'string(name)')` *(NEW C++)* | **243.9 µs** | **3,903** | **3.95 KB** | **~15.8x faster** |
| `!is.na(xml_find_first(x, 'active[...]'))` | 5.09 ms | 194 | 7.95 KB | 1.0x *(baseline)* |
| `xml_find_lgl(x, 'boolean(...)')` *(OLD `vapply`)* | 4.24 ms | 231 | 2.00 KB | 1.2x |
| `xml_find_lgl(x, 'boolean(...)')` *(NEW C++)* | **312.0 µs** | **3,071** | **2.00 KB** | **~16.3x faster** |
| `xml_find_num(x, 'number(...)')` *(OLD `vapply`)* | 4.25 ms | 231 | 3.95 KB | 1.0x |
| `xml_find_num(x, 'number(...)')` *(NEW C++)* | **233.2 µs** | **4,175** | **3.95 KB** | **~18.2x faster** |
| `xml_find_int(x, 'count(...)')` *(OLD `vapply`)* | 4.09 ms | 240 | 2.00 KB | 1.0x |
| `xml_find_int(x, 'count(...)')` *(NEW C++)* | **192.4 µs** | **5,032** | **2.00 KB** | **~21.3x faster** |

---

#### Large Nodeset ($N = 5{,}000$ items)

| Expression | Median Time | Iterations/sec | Memory Allocated | Speedup vs Baseline |
| :--- | :--- | :--- | :--- | :--- |
| `xml_text(xml_find_first(x, 'name'))` | 50.97 ms | 17.8 | 78.2 KB | 1.0x *(baseline)* |
| `xml_find_chr(x, 'string(name)')` *(OLD `vapply`)* | 73.16 ms | 13.5 | 39.1 KB | 0.70x |
| `xml_find_chr(x, 'string(name)')` *(NEW C++)* | **1.88 ms** | **432** | **39.1 KB** | **~27.1x faster** (vs `xml_text`)<br>**~38.9x faster** (vs old `xml_find_chr`) |
| `!is.na(xml_find_first(x, 'active[...]'))` | 79.80 ms | 13.2 | 78.3 KB | 1.0x *(baseline)* |
| `xml_find_lgl(x, 'boolean(...)')` *(OLD `vapply`)* | 65.00 ms | 15.0 | 19.6 KB | 1.2x |
| `xml_find_lgl(x, 'boolean(...)')` *(NEW C++)* | **2.60 ms** | **371** | **19.6 KB** | **~30.7x faster** (vs `!is.na`)<br>**~25.0x faster** (vs old `xml_find_lgl`) |
| `xml_find_num(x, 'number(...)')` *(OLD `vapply`)* | 42.66 ms | 23.4 | 39.1 KB | 1.0x |
| `xml_find_num(x, 'number(...)')` *(NEW C++)* | **1.82 ms** | **511** | **39.1 KB** | **~23.4x faster** |
| `xml_find_int(x, 'count(...)')` *(OLD `vapply`)* | 39.75 ms | 25.2 | 19.6 KB | 1.0x |
| `xml_find_int(x, 'count(...)')` *(NEW C++)* | **1.44 ms** | **656** | **19.6 KB** | **~27.6x faster** |

<details>
<summary>Benchmark script</summary>

```r
library(xml2)
library(bench)

# Generate a synthetic XML catalog of N records
generate_xml <- function(n) {
  items <- sprintf(
    "<item id=\"%d\"><name>Product_%d</name><price>%.2f</price><stock>%d</stock><active>%s</active></item>",
    seq_len(n), seq_len(n), seq_len(n) * 1.5, seq_len(n) * 10L, ifelse(seq_len(n) %% 2 == 0, "true", "false")
  )
  xml_str <- paste0("<catalog>\n", paste(items, collapse = "\n"), "\n</catalog>")
  read_xml(xml_str)
}

# Baseline vapply implementations in xml2 <= 1.6.0
old_find_chr <- function(x, xpath, ns = xml_ns(x)) {
  vapply(x, \(x) xml_find_chr.xml_node(x, xpath = xpath, ns = ns), character(1))
}
old_find_lgl <- function(x, xpath, ns = xml_ns(x)) {
  vapply(x, \(x) xml_find_lgl.xml_node(x, xpath = xpath, ns = ns), logical(1))
}
old_find_num <- function(x, xpath, ns = xml_ns(x)) {
  vapply(x, \(x) xml_find_num.xml_node(x, xpath = xpath, ns = ns), numeric(1))
}
old_find_int <- function(x, xpath, ns = xml_ns(x)) {
  vapply(x, \(x) xml_find_int.xml_node(x, xpath = xpath, ns = ns), integer(1))
}

for (n in c(50, 500, 5000, 50000, 500000)) {
  run_bench = function(...) {
    print(bench::mark(..., iterations = if (n >= 5000) 30 else 100, check = TRUE))
  }
  doc <- generate_xml(n)
  items <- xml_find_all(doc, ".//item")

  # 1. String Extraction
  run_bench(
    `xml_text(xml_find_first(x, 'name'))`          = xml_text(xml_find_first(items, "name")),
    `xml_find_chr(x, 'string(name)') [OLD vapply]` = old_find_chr(items, "string(name)"),
    `xml_find_chr(x, 'string(name)') [NEW C++]`    = xml_find_chr(items, "string(name)")
  )

  # 2. Boolean Existence Query
  run_bench(
    `!is.na(xml_find_first(x, 'active[...]'))`      = !is.na(xml_find_first(items, "active[text()='true']")),
    `xml_find_lgl(x, 'boolean(...)') [OLD vapply]` = old_find_lgl(items, "boolean(active[text()='true'])"),
    `xml_find_lgl(x, 'boolean(...)') [NEW C++]`    = xml_find_lgl(items, "boolean(active[text()='true'])")
  )

  # 3. Numeric Extraction
  run_bench(
    `xml_find_num(x, 'number(price)') [OLD vapply]` = old_find_num(items, "number(price)"),
    `xml_find_num(x, 'number(price)') [NEW C++]`    = xml_find_num(items, "number(price)")
 )
  run_bench(
    `xml_find_int(x, 'count(*)') [OLD vapply]`      = old_find_int(items, "count(*)"),
    `xml_find_int(x, 'count(*)') [NEW C++]`         = xml_find_int(items, "count(*)")
  )
}
```

</details>